### PR TITLE
로그인 시 서버 토큰을 쿠키에 세팅

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const logger = require('morgan');
+const cookieParser = require('cookie-parser');
 const cors = require('cors');
 
 const userRouter = require('./routes/userRouter');
@@ -10,7 +11,14 @@ const errorHandler = require('./middlewares/errorHandler');
 const app = express();
 
 connectDB();
-app.use(cors());
+
+app.use(
+  cors({
+    origin: [process.env.ENV === 'development' && 'http://localhost:3000'],
+    credentials: true,
+  }),
+);
+app.use(cookieParser());
 app.use(express.json());
 app.use(logger('dev'));
 app.use(express.urlencoded({ extended: true }));

--- a/constants/errorConstants.js
+++ b/constants/errorConstants.js
@@ -1,2 +1,3 @@
 const INVALID_TOKEN = 'invalid token';
 const UNAUTHORIZED = 'Unauthorized user';
+const TOKEN_DOES_NOT_EXIST = 'token does not exist';

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -1,5 +1,7 @@
 const User = require('../models/User');
 const asyncCatcher = require('../utils/asyncCatcher');
+const { createServerToken } = require('../services/userService');
+const { NONAME } = require('dns');
 
 const postLogin = asyncCatcher(async (req, res, next) => {
   const { userInfo } = req;
@@ -17,7 +19,14 @@ const postLogin = asyncCatcher(async (req, res, next) => {
     targetUser = (await User.create(user))._doc;
   }
 
+  const serverToken = createServerToken(targetUser._id);
+  console.log(serverToken);
+
+  res.cookie('server_token', serverToken, { sameSite: 'none', secure: true });
+
   res.json({
+    ok: true,
+    status: 200,
     userInformation: {
       email: targetUser.email,
       picture: targetUser.picture,
@@ -29,11 +38,33 @@ const postLogin = asyncCatcher(async (req, res, next) => {
       tiredness: targetUser.tiredness,
       exp: targetUser.exp,
       happiness: targetUser.happiness,
-      id: targetUser._id,
+    },
+  });
+});
+
+const getUserInformation = asyncCatcher(async (req, res, next) => {
+  const { userId } = req;
+  const targetUser = await User.findById(userId);
+
+  res.json({
+    ok: true,
+    status: 200,
+    userInformation: {
+      email: targetUser.email,
+      picture: targetUser.picture,
+      state: targetUser.state,
+      growth: targetUser.growth,
+      fun: targetUser.fun,
+      hunger: targetUser.hunger,
+      birthCount: targetUser.birthCount,
+      tiredness: targetUser.tiredness,
+      exp: targetUser.exp,
+      happiness: targetUser.happiness,
     },
   });
 });
 
 module.exports = {
   postLogin,
+  getUserInformation,
 };

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -20,7 +20,6 @@ const postLogin = asyncCatcher(async (req, res, next) => {
   }
 
   const serverToken = createServerToken(targetUser._id);
-  console.log(serverToken);
 
   res.cookie('server_token', serverToken, { sameSite: 'none', secure: true });
 

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,8 +1,13 @@
 const admin = require('../firebase/firebase-config');
 const CustomError = require('../utils/CustomError');
-
 const asyncCatcher = require('../utils/asyncCatcher');
-const { INVALID_TOKEN, UNAUTHORIZED } = require('../constants/errorConstants');
+const jwt = require('jsonwebtoken');
+
+const {
+  INVALID_TOKEN,
+  UNAUTHORIZED,
+  TOKEN_DOES_NOT_EXIST,
+} = require('../constants/errorConstants');
 
 const verifyToken = asyncCatcher(async (req, res, next) => {
   const [bearer, token] = req.body.accessToken.split(' ');
@@ -22,6 +27,19 @@ const verifyToken = asyncCatcher(async (req, res, next) => {
   next();
 });
 
+const isLoggedIn = asyncCatcher(async (req, res, next) => {
+  if (!req.cookies['server_token']) {
+    return next(new Error(TOKEN_DOES_NOT_EXIST));
+  }
+
+  const userIdToken = req.cookies['server_token'];
+  const userId = jwt.verify(userIdToken, process.env.TOKEN_SECRET);
+  req.userId = userId;
+
+  next();
+});
+
 module.exports = {
   verifyToken,
+  isLoggedIn,
 };

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,4 +1,8 @@
-const { INVALID_TOKEN, UNAUTHORIZED } = require('../constants/errorConstants');
+const {
+  INVALID_TOKEN,
+  UNAUTHORIZED,
+  TOKEN_DOES_NOT_EXIST,
+} = require('../constants/errorConstants');
 
 function errorHandler(err, req, res, next) {
   let error = { ...err, name: err.name, message: err.message };
@@ -19,6 +23,12 @@ function errorHandler(err, req, res, next) {
         ok: false,
         status: 400,
         message: '인증되지 않은 사용자입니다.',
+      });
+    case TOKEN_DOES_NOT_EXIST:
+      return res.json({
+        ok: false,
+        status: 400,
+        message: '로그인 토큰이 존재하지 않습니다.',
       });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "firebase-admin": "^11.0.0",
+        "jsonwebtoken": "^8.5.1",
         "mongoose": "^6.4.3",
         "morgan": "^1.10.0"
       },
@@ -956,6 +958,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4503,6 +4525,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   },
   "homepage": "https://github.com/yb9255/tamagotchi-server#readme",
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "firebase-admin": "^11.0.0",
+    "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.4.3",
     "morgan": "^1.10.0"
   },

--- a/routes/userRouter.js
+++ b/routes/userRouter.js
@@ -1,9 +1,13 @@
 const express = require('express');
-const { postLogin } = require('../controllers/user.controller');
-const { verifyToken } = require('../middlewares/auth');
+const {
+  postLogin,
+  getUserInformation,
+} = require('../controllers/user.controller');
+const { verifyToken, isLoggedIn } = require('../middlewares/auth');
 
 const router = express.Router();
 
 router.post('/login', verifyToken, postLogin);
+router.get('/userInformation', isLoggedIn, getUserInformation);
 
 module.exports = router;

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,0 +1,9 @@
+const jwt = require('jsonwebtoken');
+
+function createServerToken(id) {
+  return jwt.sign(id.toHexString(), process.env.TOKEN_SECRET);
+}
+
+module.exports = {
+  createServerToken,
+};


### PR DESCRIPTION
## 개요
- 사용자가 로그인 시 올바른 액세스 토큰을 보냈다면, 그 사용자의 db id를 jwt 토큰으로 바꾼 뒤 쿠키에 server_token이라는 이름으로 설정함
- 로그인한 사용자가 데이터를 요청하면 server_token을 분석한 다음 일치하는 경우 데이터를 보내줌.

## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- 사용자가 로그인 시 server_token을 쿠키에 저장시킴
- 로그인한 사용자한테만 응답해야하는 api의 경우 isLoggedIn을 거치도록 함.

```js
// user.controller.js / postLogin
 res.cookie('server_token', serverToken, { sameSite: 'none', secure: true });
 
// middlewares /auth.js
const isLoggedIn = asyncCatcher(async (req, res, next) => {
  if (!req.cookies['server_token']) {
    return next(new Error(TOKEN_DOES_NOT_EXIST));
  }

  const userIdToken = req.cookies['server_token'];
  const userId = jwt.verify(userIdToken, process.env.TOKEN_SECRET);
  req.userId = userId;

  next();
});
```

## 자가 체크리스트

- [x] PR 이전에 코드를 자가점검 했습니다.

- [x] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.
칸반보드 내용을 쿠키를 사용하는 것으로 변경함

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 현 시점까지 상황 요약 + 추가로 해야 할 일
- 프론트엔드에서 바뀐 다마고치 데이터를 보낼 때 그에 대응해서 데이터 변경
- 사용자 프로필 공유에 채팅 기능을 넣기 위한 소켓 기능 구현 필요